### PR TITLE
Remove folder output

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,10 @@ Usage of mksub:
         Input domain
   -df string
         Input domain file, one domain per line
-  -file string
-        Output file(s) name (default "output.txt")
   -l int
         Subdomain level to generate (default 1)
-  -nf int
-        Number of files to split the output into (faster with multiple files) (default 1)
   -o string
-        Output folder (stdout will be used when omitted)
+        Output file (stdout will be used when omitted)
   -r string
         Regex to filter words from wordlist file
   -silent


### PR DESCRIPTION
Removed the option to split the output into multiple files and store it into a folder. Avoid platform edge case behaviours and keep things simple but still super fast.